### PR TITLE
feat(componentMemberOrder): created more verbose error messages

### DIFF
--- a/src/componentMemberOrderRule.ts
+++ b/src/componentMemberOrderRule.ts
@@ -212,8 +212,8 @@ function walk(ctx: Lint.WalkContext<Options>) {
 
 
                         return addFailureToNodeGroup(ctx, failures, Rule.FAILURE_STRING_GROUP
-                        .replace('%a', VERBOSE_COMPONENT_MEMBERS[groups[0]] || groups[0])
-                        .replace('%b', VERBOSE_COMPONENT_MEMBERS[groups[1] || misplacedGroupMemberKey]));
+                        .replace(/\%a/g, VERBOSE_COMPONENT_MEMBERS[groups[0]] || groups[0])
+                        .replace(/\%b/g, VERBOSE_COMPONENT_MEMBERS[groups[1] || misplacedGroupMemberKey]));
                     }
                     return;
                 }
@@ -228,7 +228,7 @@ function walk(ctx: Lint.WalkContext<Options>) {
                     const next = existing[existing.indexOf(group) + 1];
                     const failures = collected.filter(x => x.key === group).map(x => x.node);
 
-                    addFailureToNodeGroup(ctx, failures, Rule.FAILURE_STRING_ORDER.replace('%a', group).replace('%b', () => {
+                    addFailureToNodeGroup(ctx, failures, Rule.FAILURE_STRING_ORDER.replace(/\%a/g, group).replace(/\%b/g, () => {
                         if (next && prev) {
                             return `between "${prev}" and "${next}"`
                         } else if (next) {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -10,3 +10,19 @@ export const STENCIL_METHODS = [
     'hostData',
     'render'
 ]
+
+export const VERBOSE_COMPONENT_MEMBERS: Record<string, string> = {
+    element: '@Element property',
+    event: '@Event properties',
+    'internal-prop': 'internal properties',
+    lifecycle: 'lifecycle methods',
+    listen: '@Listen methods',
+    'own-method': 'regular internal methods',
+    'own-prop': 'regular internal properties',
+    prop: '@Prop properties without watcher',
+    state: '@State properties without watcher',
+    'stencil-method': 'render() or hostData() methods',
+    watch: '@Watch methods',
+    'watched-prop': '@Prop properties with a watcher',
+    'watched-state': '@State properties with a watcher',
+}

--- a/test/rules/component-member-order/combined/component-member-order.lint
+++ b/test/rules/component-member-order/combined/component-member-order.lint
@@ -24,7 +24,7 @@ export class Component {
 export class Component {
   @Event() myEvent: EventEmitter<void>;
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [failure-order]
-  
+
   @Prop() myPropA: string;
   ~~~~~~~~~~~~~~~~~~~~~~~~
   @Prop() myPropC: string;
@@ -48,5 +48,5 @@ export class Component {
 }
 
 [failure-order]: Component member "event" should be placed after "prop"
-[failure-group]: Component members of the same type should be grouped together
+[failure-group]: @Prop properties without watcher and @Event properties should not be mixed
 [failure-alphabetical]: Component members of the same type should be alphabetized

--- a/test/rules/component-member-order/group/simple.lint
+++ b/test/rules/component-member-order/group/simple.lint
@@ -5,7 +5,7 @@ export class Component {
 
   num: number;
   someText = 'default';
-  
+
   @Element() el: HTMLElement;
 
   @Prop() content: string;
@@ -30,4 +30,4 @@ export class Component {
   }
 }
 
-[failure]: Component members of the same type should be grouped together
+[failure]: @Prop properties without watcher and @State properties without watcher should not be mixed


### PR DESCRIPTION
This PR creates more verbose error messages which is especially useful when just starting out with tslint-stencil. It took me over an hour to realize that some props of the larger components had props with `@Watch` methods that were not immediately visible leaving me very frustrated why the grouping lint error was firing on my props group.